### PR TITLE
Add NIP-05 verification

### DIFF
--- a/public/.well-known/nostr.json
+++ b/public/.well-known/nostr.json
@@ -1,0 +1,10 @@
+{
+  "names": {
+    "matt": "ca27dd905566a4a0e3ac034afc0e5cf060314e6950f4d296fd8cabe99885a039"
+  },
+  "relays": {
+    "ca27dd905566a4a0e3ac034afc0e5cf060314e6950f4d296fd8cabe99885a039": [
+      "wss://relay.primal.net/"
+    ]
+  }
+}


### PR DESCRIPTION
## What changed

- Added `/.well-known/nostr.json` for `matt@mmatt.net`
- Mapped the identifier to Matt's Nostr public key in hex format
- Added `wss://relay.primal.net/` as the public key's relay hint

## Why

This enables self-hosted NIP-05 verification through `mmatt.net`, giving the Nostr account a human-readable identifier.

## Validation

- Parsed the file successfully with `jq`
- Ran `bun run typecheck`
- Ran a successful production `bun run build`
- Confirmed the built endpoint returns HTTP 200 and `Access-Control-Allow-Origin: *`
